### PR TITLE
Remove redundant BUILD_TESTING option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,9 +86,6 @@ endif ()
 option(BUILD_SHARED_LIBS "Build shared libraries." ON)
 mark_as_superbuild(BUILD_SHARED_LIBS)
 
-option(BUILD_TESTING "Build testing" OFF)
-mark_as_superbuild(BUILD_TESTING)
-
 if (VTK_MODULE_CMAKE_MODULE_PATH)
   list(INSERT CMAKE_MODULE_PATH 0 ${VTK_MODULE_CMAKE_MODULE_PATH})
 endif ()


### PR DESCRIPTION
Setting the option `VTK_BUILD_TESTING` already allows to enable/disable testing as well as setting `BUILD_TESTING` in the current scope.

For reference, the `BUILD_TESTING` option became obsolete after integrating 363224e0f (Add support for externally building tests of a VTK modules)